### PR TITLE
Update py_mstr.py for logging out

### DIFF
--- a/py_mstr/py_mstr.py
+++ b/py_mstr/py_mstr.py
@@ -137,7 +137,7 @@ class MstrClient(object):
         return Attribute(d('dssid')[0].text, d('n')[0].text)
 
     def _logout(self):
-        arguments = {'sessionState': self._session}
+        arguments = {'sessionState': self._session, 'taskId': 'logout'}
         arguments.update(BASE_PARAMS)
         result = self._request(arguments)
         logging.info("logging out returned %s" % result)


### PR DESCRIPTION
Found sessions being left open causing 'max # of sessions' error after exceeding defined threshold.

change: added taskId 'logout' to arguments passed during logout request 
